### PR TITLE
update to `defaults` for settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ install:
 # command to run tests
 script:
   - flake8 . --max-line-length=120
-  - pep257 . --ignore=D202
+  - pep257 . --ignore=D202,D203

--- a/linter.py
+++ b/linter.py
@@ -14,14 +14,12 @@ from SublimeLinter.lint import NodeLinter
 
 
 class Semistandard(NodeLinter):
-
     """Provides an interface to semistandard."""
 
-    syntax = ('javascript', 'html', 'javascriptnext', 'javascript 6to5', 'javascript (babel)')
+    defaults = {
+        'selector': 'source.js, source.js.embedded.html, source.javascript, source.javascript.babel'
+    }
     cmd = 'semistandard --stdin --verbose'
-    version_args = '--version'
-    version_re = r'(?P<version>\d+\.\d+\.\d+)'
-    version_requirement = '>= 4.0.3'
     regex = r'^\s.+:(?P<line>\d+):(?P<col>\d+):(?P<message>.+)'
     selectors = {
         'html': 'source.js.embedded.html'


### PR DESCRIPTION
match the new requirements of sublimelinter 4.0 and reslove those error messages :

```
semistandard: Defining 'cls.syntax' has no effect anymore. Use http://www.sublimelinter.com/en/stable/linter_settings.html#selector instead.
semistandard: Defining 'cls.selectors' has no effect anymore. Use http://www.sublimelinter.com/en/stable/linter_settings.html#selector instead.
semistandard: Defining 'cls.version_args' has no effect. Please cleanup and remove these settings.
semistandard: Defining 'cls.version_re' has no effect. Please cleanup and remove these settings.
semistandard: Defining 'cls.version_requirement' has no effect. Please cleanup and remove these settings.
semistandard disabled. 'cls.defaults' is mandatory and MUST be a dict.
```
